### PR TITLE
fix: cast inPos to int for array index calculation in ParserFunctions

### DIFF
--- a/includes/ParserFunctions.php
+++ b/includes/ParserFunctions.php
@@ -986,8 +986,8 @@ class ParserFunctions {
 
 		if ( $inPos >= 0 && isset( $matches[$inPos] ) ) {
 			$result = $matches[$inPos];
-		} elseif ( $inPos < 0 && isset( $matches[count( $matches ) + $inPos] ) ) {
-			$result = $matches[count( $matches ) + $inPos];
+		} elseif ( $inPos < 0 && isset( $matches[count( $matches ) + (int)$inPos] ) ) {
+			$result = $matches[count( $matches ) + (int)$inPos];
 		} else {
 			$result = '';
 		}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T403241

This pull request includes a small fix to the `runExplode` function in `includes/ParserFunctions.php`. The change ensures that negative index values are explicitly cast to integers before being used to access array elements, which improves type safety and consistency.

* Explicitly cast negative index values to integer when accessing elements in the `$matches` array in the `runExplode` function.

to test it set 

`$inPos = "- 1";`